### PR TITLE
fix typo in default bookmarks

### DIFF
--- a/GemiNaut/App.config
+++ b/GemiNaut/App.config
@@ -18,7 +18,7 @@
                 <value>Fabric (site specific themes)</value>
             </setting>
             <setting name="Bookmarks" serializeAs="String">
-                <value>=&gt; gemini://gemini.marmaladefoo.com/geminaut GemNaut home page
+                <value>=&gt; gemini://gemini.marmaladefoo.com/geminaut GemiNaut home page
 =&gt; gemini://gemini.circumlunar.space/ Gemini project home page
 =&gt; gemini://gus.guru/ GUS search engine</value>
             </setting>

--- a/GemiNaut/Properties/Settings.Designer.cs
+++ b/GemiNaut/Properties/Settings.Designer.cs
@@ -49,7 +49,7 @@ namespace GemiNaut.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("=> gemini://gemini.marmaladefoo.com/geminaut GemNaut home page\r\n=> gemini://gemin" +
+        [global::System.Configuration.DefaultSettingValueAttribute("=> gemini://gemini.marmaladefoo.com/geminaut GemiNaut home page\r\n=> gemini://gemin" +
             "i.circumlunar.space/ Gemini project home page\r\n=> gemini://gus.guru/ GUS search " +
             "engine")]
         public string Bookmarks {

--- a/GemiNaut/Properties/Settings.settings
+++ b/GemiNaut/Properties/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)">Fabric (site specific themes)</Value>
     </Setting>
     <Setting Name="Bookmarks" Type="System.String" Scope="User">
-      <Value Profile="(Default)">=&gt; gemini://gemini.marmaladefoo.com/geminaut GemNaut home page
+      <Value Profile="(Default)">=&gt; gemini://gemini.marmaladefoo.com/geminaut GemiNaut home page
 =&gt; gemini://gemini.circumlunar.space/ Gemini project home page
 =&gt; gemini://gus.guru/ GUS search engine</Value>
     </Setting>


### PR DESCRIPTION
default bookmark spells it `GemNaut` instead of `GemiNaut`